### PR TITLE
Updated README.md with correct script command

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ npm install
 
 ### Compiles and hot-reloads for development
 ```
-npm run serve
+npm run dev
 ```
 
 ### Compiles and minifies for production


### PR DESCRIPTION
The script for running in development is ```dev``` and not ```serve``` as specified in the README.md.